### PR TITLE
Respect `ranking_strategy` parameter in `ComEM`

### DIFF
--- a/src/compound.py
+++ b/src/compound.py
@@ -25,6 +25,7 @@ class ComEM:
     ):
         self.ranking_model_name = ranking_model_name
         self.selecting_model_name = selecting_model_name
+        self.ranking_strategy = ranking_strategy
         if self.ranking_strategy == "matching":
             self.ranker = MatchingSQ(model_name=ranking_model_name)
         elif self.ranking_strategy == "comparing":


### PR DESCRIPTION
Fixes a constructor bug in `ComEM`: the `ranking_strategy` argument was accepted but never assigned as an attribute to the instance, so the default `"matching"` strategy was always used.

This one line PR stores the provided argument on `self.ranking_strategy` before selecting the ranker.